### PR TITLE
Fix runtime with sqlite >= 3.41.0

### DIFF
--- a/zim/notebook/index/__init__.py
+++ b/zim/notebook/index/__init__.py
@@ -138,7 +138,8 @@ class Index(SignalEmitter):
 	def _db_init(self):
 		tables = [r[0] for r in self._db.execute(
 			'SELECT name FROM sqlite_master '
-			'WHERE type="table" and name NOT LIKE "sqlite%"'
+			'WHERE type=? and name NOT LIKE ?',
+			('table', 'sqlite%')
 		)]
 		for table in tables:
 			self._db.execute('DROP TABLE %s' % table)


### PR DESCRIPTION
Since version 3.41.0 sqlite disabled option SQLITE_DBCONFIG_DQS_DDL [1] by default. It has been used to permitt the use of double quotes around string literals for compatiblity with MySQL 3.x. So update the code to not use double quotes. It's the only place with such a problem, as I can tell. This fixes issue #2603

[1] https://sqlite.org/quirks.html#dblquote